### PR TITLE
Remove snapshot branch protection rule

### DIFF
--- a/otterdog/eclipse-fennec.jsonnet
+++ b/otterdog/eclipse-fennec.jsonnet
@@ -16,7 +16,6 @@ local newFennecRepo(repoName, default_branch = 'snapshot') = orgs.newRepo(repoNa
   homepage: "https://projects.eclipse.org/projects/modeling.fennec",
   branch_protection_rules: [
     branchProtectionRule('main') {},
-    branchProtectionRule('snapshot') {},
   ],
 };
 


### PR DESCRIPTION
Removed branch protection rule for 'snapshot'.

This is too much efford in development, as still have much projects in pre-first-release state